### PR TITLE
Actually deactivate warning 4.

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -15,6 +15,6 @@
       "subdirs": false
     }
   ],
-  "bsc-flags": ["-bs-no-version-header", "-warn-error @a-4"],
+  "bsc-flags": ["-bs-no-version-header", "-warn-error @a", "-w -4"],
   "bs-dependencies": []
 }


### PR DESCRIPTION
I installed this library recently and got an annoying warning no. 4. This does not work in our setup, where we lift all warnings to errors in CI.

I think the behavior of "-warn-error @a-4" is a bit confusing here, because it promotes the warning 4 (which is disabled by default) to an error with @a and then downgrades it again to a warning.